### PR TITLE
Added region to config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,9 @@ class ServerlessOfflineSns {
         } else if (this.serverless.config.servicePath) {
             this.location = this.serverless.config.servicePath;
         }
-        if (this.serverless.service.provider.region) {
+        if (this.config.region) {
+            this.region = this.config.region;
+        } else if (this.serverless.service.provider.region) {
             this.region = this.serverless.service.provider.region;
         } else {
             this.region = "us-east-1";


### PR DESCRIPTION
Added possibility to define the region on the configuration of the plugin. 
``` typescript
'serverless-offline-sns': {
    port: 5002,
    debug: false,
    subscriptions: [],
    region: 'us-west-2'
},
```